### PR TITLE
fix: preserve Source Control diff view for env files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "webpack-cli": "^6.0.1"
       },
       "engines": {
-        "vscode": "^1.103.0"
+        "vscode": "^1.120.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Protect your secrets from being exposed",
   "version": "1.0.12",
   "engines": {
-    "vscode": "^1.103.0"
+    "vscode": "^1.120.0"
   },
   "publisher": "sametcn99",
   "icon": "icon.png",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
         "viewType": "env-protector.envFileEditor",
         "displayName": "env-protector Environment File Editor",
         "priority": "default",
+        "diffEditorPriority": "option",
         "selector": [
           {
             "filenamePattern": "**/.env*"


### PR DESCRIPTION
## Summary

- keep Env Protector as the default custom editor for normal `.env` file opens
- let VS Code's built-in text editor handle Source Control diffs
- align the minimum VS Code version with `diffEditorPriority` support

## Root cause

The custom editor's `default` priority also applied when VS Code opened a changed environment file as a diff. Choosing the default editor from Env Protector then reopened only one diff resource, so the comparison context was lost and users could see the old content by itself.

Setting `diffEditorPriority` to `option` keeps the protective prompt for regular file opens while allowing Source Control to use the normal text diff editor.

Fixes #8.

## Validation

- `npm run compile`
- `npm run package`
- manifest and lockfile metadata assertion
- `npm pack --dry-run --ignore-scripts`
- `git diff --check`
